### PR TITLE
Replace underscores in username derived domain

### DIFF
--- a/src/internet.js
+++ b/src/internet.js
@@ -34,7 +34,7 @@ module.exports = function(randopeep){
 		domain:function(derived){
 			return randopeep.format(
 				'{0}.{1}',
-				internet.username(derived),
+				internet.username(derived).replace('_','-'),
 				randopeep.get('domain/suffix')
 			);
 		},


### PR DESCRIPTION
Returns e.g. cool-guy.com instead of the invalid cool_guy.com
